### PR TITLE
The nano nuke

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,9 @@ RELEASE="$(rpm -E %fedora)"
 
 #systemctl enable podman.socket
 
-# Add Papirus icon theme and userspace driver for Corsair mice
+# Add (in order):
+# The Papirus icon theme
+# A userspace driver for Corsair gaming mice
 rpm-ostree install papirus-icon-theme ckb-next
 # Nuke nano from orbit
 rpm-ostree remove default-editor nano-default-editor nano

--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,7 @@ RELEASE="$(rpm -E %fedora)"
 # The Papirus icon theme
 # A userspace driver for Corsair gaming mice
 rpm-ostree install papirus-icon-theme ckb-next
+systemctl enable ckb-next-daemon.service
 
 # Remove (in order):
 # The nano text editor (install nano via homebrew, or to containers as needed)

--- a/build.sh
+++ b/build.sh
@@ -25,4 +25,4 @@ RELEASE="$(rpm -E %fedora)"
 # Add Papirus icon theme and userspace driver for Corsair mice
 rpm-ostree install papirus-icon-theme ckb-next
 # Nuke nano from orbit
-#rpm-ostree remove default-editor nano-default-editor nano
+rpm-ostree remove default-editor nano-default-editor nano

--- a/build.sh
+++ b/build.sh
@@ -34,4 +34,4 @@ rpm-ostree uninstall default-editor nano-default-editor nano input-leap input-re
 
 # Export ViM as $EDITOR in /etc/profile.d/
 # Used for system-level root tasks, such as sudoedit or visudo
-# rpm-ostree install vim-default-editor
+rpm-ostree install vim-default-editor

--- a/build.sh
+++ b/build.sh
@@ -26,5 +26,12 @@ RELEASE="$(rpm -E %fedora)"
 # The Papirus icon theme
 # A userspace driver for Corsair gaming mice
 rpm-ostree install papirus-icon-theme ckb-next
-# Nuke nano from orbit
-rpm-ostree remove default-editor nano-default-editor nano
+
+# Remove (in order):
+# The nano text editor (install nano via homebrew, or to containers as needed)
+# input-* packages (overlay packages; not present in uBlue main)
+rpm-ostree uninstall default-editor nano-default-editor nano input-leap input-remapper
+
+# Export ViM as $EDITOR in /etc/profile.d/
+# Used for system-level root tasks, such as sudoedit or visudo
+# rpm-ostree install vim-default-editor


### PR DESCRIPTION
- Remove nano
- Enable `ckb-next-daemon.service` (to automatically start the service before the next image is booted, requiring no user intervention. We are cloud-native, after all.)
- Make vim the default `$EDITOR`